### PR TITLE
Add rate limiting middleware

### DIFF
--- a/src/gateway/middleware/rate-limit.ts
+++ b/src/gateway/middleware/rate-limit.ts
@@ -1,0 +1,35 @@
+import { Request, Response, NextFunction } from "express";
+import { redis } from "../../shared/cache";
+
+interface RateLimitConfig {
+  windowMs: number;
+  maxRequests: number;
+}
+
+const DEFAULT_CONFIG: RateLimitConfig = {
+  windowMs: 60000,
+  maxRequests: 100,
+};
+
+export function rateLimiter(config: RateLimitConfig = DEFAULT_CONFIG) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const key = `rate:${(req as any).user?.id || req.ip}`;
+    const current = await redis.incr(key);
+
+    if (current === 1) {
+      await redis.expire(key, Math.ceil(config.windowMs / 1000));
+    }
+
+    res.setHeader("X-RateLimit-Limit", config.maxRequests);
+    res.setHeader("X-RateLimit-Remaining", Math.max(0, config.maxRequests - current));
+
+    if (current > config.maxRequests) {
+      return res.status(429).json({
+        error: "Too many requests",
+        retryAfter: Math.ceil(config.windowMs / 1000),
+      });
+    }
+
+    next();
+  };
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { authMiddleware } from "./middleware/auth";
 import { userRouter } from "../services/user/routes";
+import { rateLimiter } from "./middleware/rate-limit";
 import { analyticsRouter } from "../services/analytics/routes";
 import { errorHandler } from "../shared/errors";
 import { logger } from "../shared/logger";
@@ -9,6 +10,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(express.json());
+app.use(rateLimiter());
 app.use(authMiddleware);
 
 app.use("/api/users", userRouter);


### PR DESCRIPTION
## Summary
- Adds Redis-backed rate limiting middleware to the API gateway
- Configurable per-route limits with sensible defaults (100 req/min)
- Returns standard X-RateLimit headers

## Why
We've seen abuse patterns hitting the user registration endpoint. This blocks brute-force attempts while keeping normal usage unaffected.

## Test plan
- [ ] Unit tests for rate limiter logic
- [ ] Integration test with Redis
- [ ] Load test to verify limits work under concurrency