### PR TITLE
Security: harden JWT validation, add token revocation

### DIFF
--- a/src/gateway/middleware/auth.ts
+++ b/src/gateway/middleware/auth.ts
@@ -1,21 +1,70 @@
 import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
 import { UnauthorizedError } from "../../shared/errors";
+import { logger } from "../../shared/logger";
 
 const JWT_SECRET = process.env.JWT_SECRET || "dev-secret";
 const PUBLIC_PATHS = ["/health", "/api/users/login", "/api/users/register"];
 
+// Token revocation list (in production, use Redis)
+const revokedTokens = new Set<string>();
+
 export function authMiddleware(req: Request, _res: Response, next: NextFunction) {
   if (PUBLIC_PATHS.includes(req.path)) return next();
 
-  const token = req.headers.authorization?.replace("Bearer ", "");
-  if (!token) throw new UnauthorizedError("Missing auth token");
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith("Bearer ")) {
+    throw new UnauthorizedError("Missing or malformed authorization header");
+  }
+
+  const token = authHeader.substring(7);
+  
+  // Check token revocation
+  const tokenHash = hashToken(token);
+  if (revokedTokens.has(tokenHash)) {
+    logger.warn("Revoked token used", { ip: req.ip, path: req.path });
+    throw new UnauthorizedError("Token has been revoked");
+  }
 
   try {
-    const decoded = jwt.verify(token, JWT_SECRET);
-    (req as any).user = decoded;
+    const decoded = jwt.verify(token, JWT_SECRET, {
+      algorithms: ["HS256"],
+      maxAge: "24h",
+      issuer: "truxt-demo-app",
+    }) as jwt.JwtPayload;
+
+    // Validate required claims
+    if (!decoded.id || !decoded.email || !decoded.role) {
+      logger.warn("Token missing required claims", { claims: Object.keys(decoded) });
+      throw new UnauthorizedError("Invalid token claims");
+    }
+
+    (req as any).user = {
+      id: decoded.id,
+      email: decoded.email,
+      role: decoded.role,
+    };
+
     next();
-  } catch {
-    throw new UnauthorizedError("Invalid or expired token");
+  } catch (err: any) {
+    if (err instanceof UnauthorizedError) throw err;
+    
+    if (err.name === "TokenExpiredError") {
+      throw new UnauthorizedError("Token expired");
+    }
+    if (err.name === "JsonWebTokenError") {
+      logger.warn("Invalid JWT presented", { error: err.message, ip: req.ip });
+      throw new UnauthorizedError("Invalid token");
+    }
+    throw new UnauthorizedError("Authentication failed");
   }
+}
+
+export function revokeToken(token: string): void {
+  revokedTokens.add(hashToken(token));
+}
+
+function hashToken(token: string): string {
+  const crypto = require("crypto");
+  return crypto.createHash("sha256").update(token).digest("hex");
 }

--- a/src/shared/crypto.ts
+++ b/src/shared/crypto.ts
@@ -13,9 +13,13 @@ export async function hashPassword(password: string): Promise<string> {
 export async function comparePassword(password: string, stored: string): Promise<boolean> {
   const [salt, hash] = stored.split(":");
   const verify = crypto.pbkdf2Sync(password, salt, 100000, 64, "sha512").toString("hex");
-  return hash === verify;
+  return crypto.timingSafeEqual(Buffer.from(hash, "hex"), Buffer.from(verify, "hex"));
 }
 
 export function generateToken(payload: Record<string, any>): string {
-  return jwt.sign(payload, JWT_SECRET, { expiresIn: JWT_EXPIRY });
+  return jwt.sign(payload, JWT_SECRET, {
+    expiresIn: JWT_EXPIRY,
+    algorithm: "HS256",
+    issuer: "truxt-demo-app",
+  });
 }


### PR DESCRIPTION
## Summary
Critical security hardening of the authentication layer:
- **Algorithm pinning**: Enforce HS256 to prevent algorithm confusion attacks
- **Claim validation**: Require id, email, role claims on every authenticated request
- **Token revocation**: In-memory revocation list (Redis-backed in follow-up PR)
- **Timing-safe comparison**: Use `crypto.timingSafeEqual` for password verification
- **Security logging**: Log revoked token usage and malformed JWT attempts

## Priority
**CRITICAL** — Addresses findings from the Q1 security audit. The algorithm confusion vulnerability (CVE-2022-23529) allows attackers to forge tokens by switching to `none` algorithm.

## Review notes
- Need security team sign-off before merge
- Token revocation is in-memory only for now — Redis-backed version tracked in TRUX-892
- Password comparison change is backwards-compatible (same hash format)

## Test plan
- [x] Verify HS256 enforcement rejects RS256/none tokens
- [x] Test token revocation flow
- [ ] Pen test with forged tokens
- [ ] Security team review