### PR TITLE
API v2 with response envelope and v1 deprecation timeline

### DIFF
--- a/src/gateway/middleware/deprecation.ts
+++ b/src/gateway/middleware/deprecation.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from "express";
+import { logger } from "../../shared/logger";
+
+const DEPRECATION_DATE = "2026-06-01";
+const SUNSET_DATE = "2026-09-01";
+
+export function v1DeprecationMiddleware(req: Request, res: Response, next: NextFunction) {
+  // Only apply to v1 routes
+  if (!req.path.startsWith("/api/") || req.path.startsWith("/api/v2/")) {
+    return next();
+  }
+
+  res.setHeader("Deprecation", `date="${DEPRECATION_DATE}"`);
+  res.setHeader("Sunset", SUNSET_DATE);
+  res.setHeader("Link", '</api/v2>; rel="successor-version"');
+
+  logger.warn("v1 API access", {
+    path: req.path,
+    userId: (req as any).user?.id,
+    userAgent: req.headers["user-agent"],
+  });
+
+  next();
+}

--- a/src/gateway/middleware/request-id.ts
+++ b/src/gateway/middleware/request-id.ts
@@ -1,0 +1,9 @@
+import { Request, Response, NextFunction } from "express";
+import crypto from "crypto";
+
+export function requestIdMiddleware(req: Request, res: Response, next: NextFunction) {
+  const requestId = (req.headers["x-request-id"] as string) || crypto.randomUUID();
+  req.headers["x-request-id"] = requestId;
+  res.setHeader("X-Request-Id", requestId);
+  next();
+}

--- a/src/gateway/v2/router.ts
+++ b/src/gateway/v2/router.ts
@@ -1,0 +1,30 @@
+import { Router } from "express";
+import { userRouter } from "../../services/user/routes";
+import { analyticsRouter } from "../../services/analytics/routes";
+import { notificationRouter } from "../../services/notification/routes";
+import { auditRouter } from "../../services/audit/routes";
+
+const v2Router = Router();
+
+// v2 wraps all responses in a standard envelope
+v2Router.use((req, res, next) => {
+  const originalJson = res.json.bind(res);
+  res.json = (body: any) => {
+    return originalJson({
+      apiVersion: "2.0",
+      data: body?.data ?? body,
+      meta: {
+        requestId: req.headers["x-request-id"] || crypto.randomUUID(),
+        timestamp: new Date().toISOString(),
+      },
+    });
+  };
+  next();
+});
+
+v2Router.use("/users", userRouter);
+v2Router.use("/analytics", analyticsRouter);
+v2Router.use("/notifications", notificationRouter);
+v2Router.use("/audit", auditRouter);
+
+export { v2Router };


### PR DESCRIPTION
## Summary
- **v2 API**: Standard response envelope with `apiVersion`, `data`, `meta` (requestId, timestamp)
- **v1 deprecation**: Adds RFC 8594 Deprecation/Sunset headers to all v1 routes
- **Request ID**: X-Request-Id propagation for distributed tracing

## Timeline
- v1 deprecated: June 1, 2026
- v1 sunset (removed): September 1, 2026

## Breaking changes
v2 wraps all responses — clients expecting raw `{ data: [...] }` need to unwrap from `{ data: { data: [...] } }`.

## Open questions
- Should we version at the URL level (/api/v2/) or via Accept header?
- Do we need a migration guide for external API consumers?
- Should the deprecation logging include request bodies for debugging?

## Test plan
- [ ] v2 response format verification
- [ ] v1 deprecation headers present
- [ ] Request ID propagation through service calls