### PR TITLE
Add RBAC middleware with role hierarchy

### DIFF
--- a/src/gateway/middleware/rbac.ts
+++ b/src/gateway/middleware/rbac.ts
@@ -1,0 +1,43 @@
+import { Request, Response, NextFunction } from "express";
+import { ForbiddenError } from "../../shared/errors";
+
+type Role = "admin" | "member" | "viewer";
+
+const ROLE_HIERARCHY: Record<Role, number> = {
+  admin: 3,
+  member: 2,
+  viewer: 1,
+};
+
+export function requireRole(...roles: Role[]) {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    const user = (req as any).user;
+    if (!user?.role) throw new ForbiddenError("No role assigned");
+    if (!roles.includes(user.role)) {
+      throw new ForbiddenError(`Requires one of: ${roles.join(", ")}`);
+    }
+    next();
+  };
+}
+
+export function requireMinRole(minRole: Role) {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    const user = (req as any).user;
+    if (!user?.role) throw new ForbiddenError("No role assigned");
+    if (ROLE_HIERARCHY[user.role as Role] < ROLE_HIERARCHY[minRole]) {
+      throw new ForbiddenError(`Requires at least ${minRole} role`);
+    }
+    next();
+  };
+}
+
+export function requireSelfOrAdmin(paramKey: string = "id") {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    const user = (req as any).user;
+    const targetId = req.params[paramKey];
+    if (user.role !== "admin" && user.id !== targetId) {
+      throw new ForbiddenError("Can only access your own resources");
+    }
+    next();
+  };
+}


### PR DESCRIPTION
## Summary
Reusable RBAC middleware replacing inline role checks:
- `requireRole('admin')` for admin-only endpoints
- `requireMinRole('member')` for member+ access
- `requireSelfOrAdmin('id')` for user's own resources

Closes TRUX-930.

## Test plan
- [x] Admin can access admin endpoints
- [x] Member blocked from admin endpoints
- [x] User can access own profile, not others