### PR TITLE
Fix developer onboarding: setup script, dev compose, .env.example (closes #54)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# ── Required ──────────────────────────────────────────────────────────────────
+NODE_ENV=development
+PORT=3000
+DATABASE_URL=postgresql://truxt:truxt_dev@localhost:5432/truxt_demo
+REDIS_URL=redis://localhost:6379
+# Must be 32+ chars. Generate: openssl rand -hex 32
+JWT_SECRET=replace-this-with-a-secure-random-string-at-least-32-chars-long
+
+# ── Optional ──────────────────────────────────────────────────────────────────
+JWT_EXPIRY=15m
+LOG_LEVEL=info
+CORS_ORIGINS=http://localhost:3000,http://localhost:4000
+RATE_LIMIT_WINDOW_MS=60000
+RATE_LIMIT_MAX=100
+
+# Email delivery (leave blank to disable email worker)
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_USER=notifications@example.com
+# SMTP_PASS=secret
+# SMTP_FROM=noreply@truxt.ai
+
+# Slack notifications (leave blank to disable)
+# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx/yyy/zzz
+
+# Observability (leave blank to disable)
+# SENTRY_DSN=https://xxx@sentry.io/yyy
+# OTEL_ENDPOINT=http://localhost:4318

--- a/README.md
+++ b/README.md
@@ -1,24 +1,46 @@
 # Truxt Demo App
 
-A sample microservice for demonstrating Truxt Axiom's engineering intelligence capabilities.
-
-## Architecture
-
-- **API Gateway** (`src/gateway/`) — Express.js request routing and auth middleware
-- **User Service** (`src/services/user/`) — User management, profiles, permissions
-- **Analytics Service** (`src/services/analytics/`) — Event tracking, dashboards, reporting
-- **Shared** (`src/shared/`) — Common utilities, database clients, error handling
+A sample microservice demonstrating engineering intelligence via Truxt Axiom.
 
 ## Quick Start
 
+**Prerequisites**: Node.js >= 20, Docker
+
 ```bash
-npm install
+git clone https://github.com/truxt-ai/truxt-demo-app
+cd truxt-demo-app
+./scripts/setup-dev.sh    # installs deps, starts Postgres/Redis, runs migrations
 npm run dev
 ```
+
+Visit http://localhost:3000/health to verify.
+
+## Manual Setup
+
+```bash
+cp .env.example .env        # fill in required vars
+docker compose -f docker-compose.dev.yml up -d
+npm install
+for f in migrations/*.sql; do psql $DATABASE_URL -f "$f"; done
+npm run dev
+```
+
+## Architecture
+
+| Layer | Tech |
+|-------|------|
+| API Gateway | Express.js with JWT + API key auth |
+| User Service | CRUD, search, profiles, RBAC |
+| Analytics Service | Event tracking, dashboards |
+| Team Service | Multi-tenant with roles and invites |
+| Notification Service | In-app, email, Slack |
+| Metrics Service | Time-series aggregation, dashboards |
+| Webhook Service | HMAC-signed outgoing webhooks |
+| Workers | Email, Slack, digest, webhook delivery |
 
 ## Testing
 
 ```bash
-npm test
-npm run test:integration
+npm test                   # unit tests
+npm run test:integration   # integration tests (requires running DB)
 ```

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,32 @@
+# Local development environment — Postgres + Redis only
+# Usage: docker compose -f docker-compose.dev.yml up -d
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: truxt_demo
+      POSTGRES_USER: truxt
+      POSTGRES_PASSWORD: truxt_dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-dev:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U truxt -d truxt_demo"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  postgres-dev:


### PR DESCRIPTION
## Problem
New developers were spending 2+ days getting the environment running. Missing docker-compose for local services, incomplete .env.example, no setup automation.

## Changes

**`scripts/setup-dev.sh`** — one-command setup:
- Checks Node >= 20 and Docker are present
- Copies .env.example, auto-generates JWT_SECRET
- Starts Postgres + Redis via docker-compose.dev.yml
- Runs all migrations in order

**`docker-compose.dev.yml`** — minimal local services:
- Postgres 15 + Redis 7, no other dependencies
- Healthchecks so the setup script can wait for ready state

**`.env.example`** — now complete:
- All required vars documented
- Optional vars (SMTP, Slack, Sentry, OTEL) clearly marked as optional with instructions

**`README.md`** — rewritten Quick Start pointing to setup script

Closes #54.